### PR TITLE
make fnmatch.translate also support globstar and make * non-greedy. 

### DIFF
--- a/src/glob2/fnmatch.py
+++ b/src/glob2/fnmatch.py
@@ -88,7 +88,11 @@ def translate(pat):
         c = pat[i]
         i = i+1
         if c == '*':
-            res = res + '(.*)'
+            if i < n and pat[i] == '*':
+                res = res + '(.*)'
+                i = i+1
+            else:
+                res = res + '([^\\' + os.path.sep + ']*)'
         elif c == '?':
             res = res + '(.)'
         elif c == '[':


### PR DESCRIPTION
eg 

before:

pattern="/home/*/cache"

would match

/home/user/cache
/home/user/something/cache
/home/suer/something/something/cache

now:

pattern="/home/*/cache"

would match

/home/user/cache
/home/user2/cache

but would not match /home/user/something/cache

pattern="/home/**/cache"

would match

/home/user/cache
/home/user/something/cache
/home/suer/something/something/cache

this brings it in line with the other functions in glob2, and although changes the functionality of a single * - makes it match the behaviour of most shells, and is more intuitive.