### PR TITLE
Fixing re flags deprecation warning in python 3.6

### DIFF
--- a/glob2/fnmatch.py
+++ b/glob2/fnmatch.py
@@ -138,4 +138,4 @@ def translate(pat):
                 res = '%s([%s])' % (res, stuff)
         else:
             res = res + re.escape(c)
-    return res + '\Z(?ms)'
+    return '(?ms)' + res + '\Z'


### PR DESCRIPTION
In Python 3.6 and beyond they have deprecated flags in re.compile that do not come at the beginning. I moved the flag to the beginning of the string instead.