### PR TITLE
Support pytest 8

### DIFF
--- a/test.py
+++ b/test.py
@@ -46,7 +46,7 @@ class TestFnmatch(object):
 
 class BaseTest(object):
 
-    def setup(self):
+    def setup_method(self):
         self.basedir = tempfile.mkdtemp()
         self._old_cwd = os.getcwd()
         os.chdir(self.basedir)
@@ -56,7 +56,7 @@ class BaseTest(object):
     def setup_files(self):
         pass
 
-    def teardown(self):
+    def teardown_method(self):
         os.chdir(self._old_cwd)
         shutil.rmtree(self.basedir)
 


### PR DESCRIPTION
Pytest 8 removes support for deprecated nose setup and teardown methods, add _method to fix that.

Fixes #30